### PR TITLE
Added block-based method for extracting the video URL to LBYouTubeExtractor

### DIFF
--- a/LBYouTubeView/LBYouTubeExtractor.h
+++ b/LBYouTubeView/LBYouTubeExtractor.h
@@ -13,6 +13,8 @@ extern NSInteger const LBYouTubePlayerExtractorErrorCodeInvalidHTML;
 extern NSInteger const LBYouTubePlayerExtractorErrorCodeNoStreamURL;
 extern NSInteger const LBYouTubePlayerExtractorErrorCodeNoJSONData;
 
+typedef void (^LBYouTubeExtractorCompletionBlock)(NSURL *videoURL, NSError *error);
+
 typedef enum {
     LBYouTubeVideoQualitySmall    = 0,
     LBYouTubeVideoQualityMedium   = 1,
@@ -32,12 +34,15 @@ typedef enum {
 @property (nonatomic, strong, readonly) NSURL* youTubeURL;
 @property (nonatomic, strong, readonly) NSURL *extractedURL;
 @property (nonatomic, unsafe_unretained) IBOutlet id <LBYouTubeExtractorDelegate> delegate;
+@property (nonatomic, strong) LBYouTubeExtractorCompletionBlock completionBlock;
 
 -(id)initWithURL:(NSURL*)videoURL quality:(LBYouTubeVideoQuality)quality;
 -(id)initWithID:(NSString*)videoID quality:(LBYouTubeVideoQuality)quality;
 
 -(void)startExtracting;
 -(void)stopExtracting;
+
+- (void)extractVideoURLWithCompletionBlock:(LBYouTubeExtractorCompletionBlock)completionBlock;
 
 @end
 @protocol LBYouTubeExtractorDelegate <NSObject>

--- a/LBYouTubeView/LBYouTubeExtractor.m
+++ b/LBYouTubeView/LBYouTubeExtractor.m
@@ -7,7 +7,7 @@
 //
 
 #import "LBYouTubeExtractor.h"
-#import "JSONKit.h"
+//#import "JSONKit.h"
 
 static NSString* const kUserAgent = @"Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3";
 
@@ -167,17 +167,8 @@ NSInteger const LBYouTubePlayerExtractorErrorCodeNoJSONData   =    3;
         NSError* decodingError = nil;
         NSDictionary* JSONCode = nil;
         
-        // First try to invoke NSJSONSerialization (Thanks Mattt Thompson)
-        
-        id NSJSONSerializationClass = NSClassFromString(@"NSJSONSerialization");
-        SEL NSJSONSerializationSelector = NSSelectorFromString(@"dataWithJSONObject:options:error:");
-        if (NSJSONSerializationClass && [NSJSONSerializationClass respondsToSelector:NSJSONSerializationSelector]) {
-            JSONCode = [NSJSONSerialization JSONObjectWithData:[JSON dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:&decodingError];
-        }
-        else {
-            JSONCode = [JSON objectFromJSONStringWithParseOptions:JKParseOptionNone error:&decodingError];
-        }
-        
+        JSONCode = [NSJSONSerialization JSONObjectWithData:[JSON dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:&decodingError];
+
         if (decodingError) {
             // Failed
             

--- a/LBYouTubeView/LBYouTubeExtractor.m
+++ b/LBYouTubeView/LBYouTubeExtractor.m
@@ -89,6 +89,11 @@ NSInteger const LBYouTubePlayerExtractorErrorCodeNoJSONData   =    3;
     [self _closeConnection];
 }
 
+- (void)extractVideoURLWithCompletionBlock:(LBYouTubeExtractorCompletionBlock)completionBlock {
+    self.completionBlock = completionBlock;
+    [self startExtracting];
+}
+
 #pragma mark -
 #pragma mark Memory
 
@@ -219,11 +224,19 @@ NSInteger const LBYouTubePlayerExtractorErrorCodeNoJSONData   =    3;
     if (self.delegate) {
         [self.delegate youTubeExtractor:self didSuccessfullyExtractYouTubeURL:videoURL];
     }
+
+    if(self.completionBlock) {
+        self.completionBlock(videoURL, nil);
+    }
 }
 
 -(void)_failedExtractingYouTubeURLWithError:(NSError *)error {
     if (self.delegate) {
         [self.delegate youTubeExtractor:self failedExtractingYouTubeURLWithError:error];
+    }
+
+    if(self.completionBlock) {
+        self.completionBlock(nil, error);
     }
 }
 

--- a/Sample/LBViewController.m
+++ b/Sample/LBViewController.m
@@ -18,7 +18,24 @@
 
 -(void)viewDidLoad {
     [super viewDidLoad];
-	
+
+    // This is just a demonstration of how you would extract
+    // a video URL using block-based syntax. It has no function
+    // in the demo app, other than it logs the extracted URL
+    // to the console, as you can see here:
+
+    LBYouTubeExtractor *extractor = [[LBYouTubeExtractor alloc] initWithURL:[NSURL URLWithString:@"http://www.youtube.com/watch?v=WVTzEq53-PI"] quality:LBYouTubeVideoQualityLarge];
+
+    [extractor extractVideoURLWithCompletionBlock:^(NSURL *videoURL, NSError *error) {
+        if(!error) {
+            NSLog(@"Did extract video URL using completion block: %@", videoURL);
+        } else {
+            NSLog(@"Failed extracting video URL using block due to error:%@", error);
+        }
+    }];
+
+    // Setup the player controller and add it's view as a subview:
+
     self.controller = [[LBYouTubePlayerController alloc] initWithYouTubeURL:[NSURL URLWithString:@"http://www.youtube.com/watch?v=1fTIhC1WSew&list=FLEYfH4kbq85W_CiOTuSjf8w&feature=mh_lolz"] quality:LBYouTubeVideoQualityLarge];
     self.controller.delegate = self;
     self.controller.view.frame = CGRectMake(0.0f, 0.0f, 200.0f, 200.0f);


### PR DESCRIPTION
I really wanted/needed to be able to extract a YouTube video URL using a block based syntax. I find it more convenient and approachable.

I'd love to see it added to this library! :smile: 

Let me know if you have any questions or concerns.

Thanks for a great bit of code mate!

— Jake
