### PR TITLE
Changes for new YouTube HTML body

### DIFF
--- a/LBYouTubeView/LBYouTubeExtractor.m
+++ b/LBYouTubeView/LBYouTubeExtractor.m
@@ -132,7 +132,7 @@ static NSString *UnescapeString(NSString *string) {
             *error = decodingError;
         }
         else {
-            NSArray* videos = [[[JSONCode objectForKey:@"content"] objectForKey:@"video"] objectForKey:@"fmt_stream_map"];
+            NSArray* videos = [[[JSONCode objectForKey:@"content"] objectForKey:@"player_data"] objectForKey:@"fmt_stream_map"];
             NSString* streamURL = nil;
             if (videos.count) {
                 NSString* streamURLKey = @"url";


### PR DESCRIPTION
YouTube changed the name of the Video-Container from "video" to "player_data". This Pull Request fixes the problem.

Maybe someone should find a more generic way of parsing to avoid such problems in the future.
