### PR TITLE
YouTube JSON structure change

### DIFF
--- a/LBYouTubeView/LBYouTubeExtractor.m
+++ b/LBYouTubeView/LBYouTubeExtractor.m
@@ -132,7 +132,7 @@ static NSString *UnescapeString(NSString *string) {
             *error = decodingError;
         }
         else {
-            NSArray* videos = [[[JSONCode objectForKey:@"content"] objectForKey:@"video"] objectForKey:@"fmt_stream_map"];
+            NSArray* videos = [[[JSONCode objectForKey:@"content"] objectForKey:@"player_data"] objectForKey:@"fmt_stream_map"];
             NSString* streamURL = nil;
             if (videos.count) {
                 NSString* streamURLKey = @"url";


### PR DESCRIPTION
YouTube changed their JSON structure again; nested JSON parameter was changed from 'video' to 'player_data'.
