### PR TITLE
Extracted URL is checked for validity before player is opened.

### DIFF
--- a/LBYouTubeView/LBYouTubeExtractor.m
+++ b/LBYouTubeView/LBYouTubeExtractor.m
@@ -128,10 +128,12 @@ NSInteger const LBYouTubePlayerExtractorErrorCodeNoJSONData   =    3;
 }
 
 -(void)failedExtractingYouTubeURLWithError:(NSError *)error {
+    
+    NSLog(@"Failed to query mp4: %@", error);
     if (self.delegate) {
         [self.delegate youTubeExtractor:self failedExtractingYouTubeURLWithError:error];
     }
-
+    
     if(self.completionBlock) {
         self.completionBlock(nil, error);
     }

--- a/LBYouTubeView/LBYouTubePlayerViewController.m
+++ b/LBYouTubeView/LBYouTubePlayerViewController.m
@@ -55,12 +55,24 @@
 #pragma mark LBYouTubeExtractorDelegate
 
 -(void)youTubeExtractor:(LBYouTubeExtractor *)extractor didSuccessfullyExtractYouTubeURL:(NSURL *)videoURL {
-    if ([self.delegate respondsToSelector:@selector(youTubePlayerViewController:didSuccessfullyExtractYouTubeURL:)]) {
-        [self.delegate youTubePlayerViewController:self didSuccessfullyExtractYouTubeURL:videoURL];
+
+    NSURL *candidateURL = videoURL;
+    if (candidateURL && candidateURL.scheme && candidateURL.host)
+    {
+        if ([self.delegate respondsToSelector:@selector(youTubePlayerViewController:didSuccessfullyExtractYouTubeURL:)]) {
+            [self.delegate youTubePlayerViewController:self didSuccessfullyExtractYouTubeURL:videoURL];
+        }
+        
+        self.moviePlayer.contentURL = videoURL;
+        [self.moviePlayer play];
     }
-    
-    self.moviePlayer.contentURL = videoURL;
-    [self.moviePlayer play];
+    else
+    {
+        NSLog(@"extracted URL is buggy: %@", videoURL);
+        if ([self.delegate respondsToSelector:@selector(youTubePlayerViewController:failedExtractingYouTubeURLWithError:)]) {
+            [self.delegate youTubePlayerViewController:self failedExtractingYouTubeURLWithError:nil];
+        }
+    }
 }
 
 -(void)youTubeExtractor:(LBYouTubeExtractor *)extractor failedExtractingYouTubeURLWithError:(NSError *)error {


### PR DESCRIPTION
If URL is invalid, delegate is called and can retry to extract the URL. This helps with the _didntPlayToEnd:-Error we are experiencing...at least until we find a fix for the real problem.
